### PR TITLE
fix `test_get_array_arg` in test_SuitBuildUtils.py

### DIFF
--- a/src/test/MobileSuit/Core/test_SuitBuildUtils.py
+++ b/src/test/MobileSuit/Core/test_SuitBuildUtils.py
@@ -111,10 +111,10 @@ class MyTestCase(unittest.TestCase):
     def test_get_array_arg(self):
         def func(args: List[int]):
             pass
-
         param = next(iter(signature(func).parameters.values()))
-        self.mock_parsing_service.Get.return_value = 42  # Mocking parsed integer
-        result, step = GetArrayArg(param, func, ["1", "2", "3"], self.context)
+        self.mock_parsing_service.Get.side_effect = lambda myT, name: lambda s: 42
+        self.mock_context.GetRequiredService.return_value = self.mock_parsing_service
+        result, step = GetArrayArg(param, func, ["1", "2", "3"], self.mock_context)
         self.assertEqual(step, 3)
         self.assertEqual(result, [42, 42, 42])
 


### PR DESCRIPTION
This is a really difficult problem.
In the previous version, only a `mock_parsing_service.Get.return_value` has been defined as `42`, which means the test want to mock the return value to be 42. 
Which I mean is the function `convert` in the `convert = CreateConverterFactory( otype, get_parser(function, parameter.name))` always retrun `42`
So it's not enough just mock the `mock_parsing_service.Get`, also have to add this `self.mock_context.GetRequiredService.return_value = self.mock_parsing_service`

But there is another problem. This will make the funtion `converter` be a type:int, not callable, leading a error in the `array.append(convert(arg))`. So I use the nesting lambda referring to the `return context.GetRequiredService(IParsingService).Get(myT, NullCollapse(myParserInfo.Name, ''))`

Here it is:
`self.mock_parsing_service.Get.side_effect = lambda myT, name: lambda s: 42`
So a inner lambda `s:42` will be returned when calling the function `converter`, but not change the converter itself to `(int)42`
![image](https://github.com/user-attachments/assets/aff438ac-85dd-4a07-995d-c5ed93de7a2b)
